### PR TITLE
feat(appointments): 🗓️ gestión de agenda doctor 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",
         "@hookform/resolvers": "^5.2.2",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-slot": "^1.2.3",
@@ -1450,6 +1451,42 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
@@ -1461,6 +1498,73 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -1490,6 +1594,30 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1704,6 +1832,24 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2778,6 +2924,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3179,6 +3337,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -3758,6 +3922,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -4937,6 +5110,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "7.9.3",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.3.tgz",
@@ -4978,6 +5198,28 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-transition-group": {
@@ -5463,6 +5705,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
@@ -5595,6 +5843,27 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-isomorphic-layout-effect": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
@@ -5602,6 +5871,28 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@hello-pangea/dnd": "^18.0.1",
     "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.3",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,141 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/features/patients/PatientsPage.tsx
+++ b/src/features/patients/PatientsPage.tsx
@@ -1,0 +1,171 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import useAppStore from "@/store/appStore";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogTrigger } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Activity, Search, Plus, Users, FileText, Calendar } from "lucide-react";
+import { format, parseISO, compareDesc } from "date-fns";
+
+function lastConsultDate(patientId: string, clinicalRecords: ReturnType<typeof useAppStore.getState>["clinicalRecords"]) {
+    const rec = clinicalRecords[patientId];
+    if (!rec || !rec.consultations.length) return null;
+    const sorted = [...rec.consultations].sort((a, b) =>
+        compareDesc(parseISO(a.dateISO), parseISO(b.dateISO))
+    );
+    return sorted[0]?.dateISO ?? null;
+}
+
+export default function PatientsPage() {
+    const navigate = useNavigate();
+    const { patients, clinicalRecords, addPatient } = useAppStore();
+    const [q, setQ] = useState("");
+    const [openNew, setOpenNew] = useState(false);
+
+    // alta rápida
+    const [name, setName] = useState("");
+    const [docId, setDocId] = useState("");
+    const [phone, setPhone] = useState("");
+
+    const filtered = useMemo(() => {
+        const query = q.trim().toLowerCase();
+        if (!query) return patients;
+        return patients.filter(
+            (p) =>
+                p.name.toLowerCase().includes(query) ||
+                p.docId.toLowerCase().includes(query)
+        );
+    }, [patients, q]);
+
+    const onCreate = () => {
+        if (!name.trim() || !docId.trim()) return;
+        const id = addPatient({ name: name.trim(), docId: docId.trim(), phone: phone.trim() || undefined, notes: "" });
+        setOpenNew(false);
+        setName(""); setDocId(""); setPhone("");
+        // Llevar directo a la historia si querés:
+        navigate(`/patients/${id}`);
+    };
+
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-primary/5 via-background to-secondary/5">
+            {/* Header */}
+            <header className="border-b bg-card/50 backdrop-blur-sm sticky top-0 z-10">
+                <div className="container mx-auto px-4 py-4 flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                        <div className="w-10 h-10 bg-gradient-primary rounded-xl flex items-center justify-center my-gradient-class">
+                            <Activity className="w-5 h-5 text-white" />
+                        </div>
+                        <div>
+                            <h1 className="text-xl font-semibold">Pacientes</h1>
+                            <p className="text-sm text-muted-foreground">Listado y acciones rápidas</p>
+                        </div>
+                    </div>
+
+                    <Dialog open={openNew} onOpenChange={setOpenNew}>
+                        <DialogTrigger asChild>
+                            <Button className="gap-2"><Plus className="w-4 h-4" /> Nuevo paciente</Button>
+                        </DialogTrigger>
+                        <DialogContent>
+                            <DialogHeader>
+                                <DialogTitle>Alta rápida de paciente</DialogTitle>
+                            </DialogHeader>
+                            <div className="space-y-3">
+                                <div className="space-y-1">
+                                    <Label>Nombre completo</Label>
+                                    <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Juan Pérez" />
+                                </div>
+                                <div className="space-y-1">
+                                    <Label>DNI / Documento</Label>
+                                    <Input value={docId} onChange={(e) => setDocId(e.target.value)} placeholder="12.345.678" />
+                                </div>
+                                <div className="space-y-1">
+                                    <Label>Teléfono (opcional)</Label>
+                                    <Input value={phone} onChange={(e) => setPhone(e.target.value)} placeholder="+54 9 ..." />
+                                </div>
+                            </div>
+                            <DialogFooter className="gap-2">
+                                <Button variant="outline" onClick={() => setOpenNew(false)}>Cancelar</Button>
+                                <Button onClick={onCreate} disabled={!name.trim() || !docId.trim()}>Crear</Button>
+                            </DialogFooter>
+                        </DialogContent>
+                    </Dialog>
+                </div>
+            </header>
+
+            <main className="container mx-auto px-4 py-6 space-y-6">
+                {/* Buscador */}
+                <Card className="shadow-sm">
+                    <CardContent className="pt-6">
+                        <div className="flex flex-col md:flex-row items-center gap-3">
+                            <div className="relative w-full md:max-w-xl">
+                                <Search className="w-4 h-4 text-muted-foreground absolute left-3 top-1/2 -translate-y-1/2" />
+                                <Input
+                                    className="pl-9"
+                                    placeholder="Buscar por nombre o documento…"
+                                    value={q}
+                                    onChange={(e) => setQ(e.target.value)}
+                                />
+                            </div>
+                            <Badge variant="secondary" className="ml-auto">
+                                <Users className="w-4 h-4 mr-1" /> {filtered.length} paciente{filtered.length === 1 ? "" : "s"}
+                            </Badge>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                {/* Listado */}
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {filtered.map((p) => {
+                        const last = lastConsultDate(p.id, clinicalRecords);
+                        return (
+                            <Card key={p.id} className="shadow-md hover:shadow-lg transition-shadow">
+                                <CardHeader>
+                                    <CardTitle className="flex items-center justify-between">
+                                        <span>{p.name}</span>
+                                        <Badge variant="outline">{p.docId}</Badge>
+                                    </CardTitle>
+                                    <CardDescription className="space-x-2">
+                                        {p.phone && <span className="text-sm">Tel: {p.phone}</span>}
+                                        {p.notes && <span className="text-sm text-muted-foreground">• {p.notes}</span>}
+                                    </CardDescription>
+                                </CardHeader>
+                                <CardContent className="flex items-center justify-between">
+                                    <div className="text-sm text-muted-foreground">
+                                        Última consulta:{" "}
+                                        {last ? format(parseISO(last), "dd/MM/yyyy") : "—"}
+                                    </div>
+                                    <div className="flex gap-2">
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            onClick={() => navigate(`/patients/${p.id}`)}
+                                        >
+                                            <FileText className="w-4 h-4 mr-2" /> Historia
+                                        </Button>
+                                        <Button
+                                            size="sm"
+                                            onClick={() => navigate(`/doctor/appointments?patientId=${p.id}`)}
+                                        >
+                                            <Calendar className="w-4 h-4 mr-2" /> Nuevo turno
+                                        </Button>
+                                    </div>
+                                </CardContent>
+                            </Card>
+                        );
+                    })}
+                </div>
+
+                {filtered.length === 0 && (
+                    <Card className="shadow-sm">
+                        <CardContent className="py-10 text-center text-muted-foreground">
+                            No se encontraron pacientes para “{q}”.
+                        </CardContent>
+                    </Card>
+                )}
+            </main>
+        </div>
+    );
+}

--- a/src/features/scheduling/DoctorAppointmentsPage.tsx
+++ b/src/features/scheduling/DoctorAppointmentsPage.tsx
@@ -1,0 +1,460 @@
+// src/features/scheduling/DoctorAppointmentsPage.tsx
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Activity, ArrowLeft, CalendarPlus, Calendar as CalIcon, CheckCircle, Clock, Edit3, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import useAppStore, { type Appointment } from "@/store/appStore";
+import { useDndOrder } from "@/hooks/useDndOrder";
+import { addMinutes, compareAsc, endOfDay, format, parseISO, startOfDay, isWithinInterval } from "date-fns";
+import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
+
+function StatusBadge({ status }: { status: "pending" | "confirmed" | "cancelled" }) {
+    if (status === "pending") return <Badge variant="secondary">pendiente</Badge>;
+    if (status === "confirmed") return <Badge>confirmada</Badge>;
+    return <Badge variant="destructive">cancelada</Badge>;
+}
+
+function hhmm(d: Date) {
+    return new Intl.DateTimeFormat(undefined, { hour: "2-digit", minute: "2-digit" }).format(d);
+}
+
+export default function DoctorAppointmentsPage() {
+    const navigate = useNavigate();
+    const {
+        currentUser,
+        currentDoctorId,
+        doctors,
+        patients,
+        appointments,
+        addAppointment,
+        updateAppointment,
+        deleteAppointment,
+    } = useAppStore();
+
+    // doctor actual (fallback al primero)
+    const doctorId = useMemo(() => {
+        return (
+            currentDoctorId ||
+            doctors.find((d) => d.name === currentUser?.name)?.id ||
+            doctors[0]?.id
+        );
+    }, [currentDoctorId, doctors, currentUser?.name]);
+
+    // filtro por día (yyyy-MM-dd)
+    const [day, setDay] = useState<string>(() => format(new Date(), "yyyy-MM-dd"));
+    useEffect(() => {
+        // sanity: si cambia doctor, mantenemos el día actual
+    }, [doctorId]);
+
+    const dayStart = useMemo(() => startOfDay(new Date(day)), [day]);
+    const dayEnd = useMemo(() => endOfDay(new Date(day)), [day]);
+
+    const dayAppts = useMemo(() => {
+        return appointments
+            .filter(
+                (a) =>
+                    a.doctorId === doctorId &&
+                    isWithinInterval(parseISO(a.startsAt), { start: dayStart, end: dayEnd })
+            )
+            .sort((a, b) => compareAsc(parseISO(a.startsAt), parseISO(b.startsAt)));
+    }, [appointments, doctorId, dayStart, dayEnd]);
+
+    // Orden persistido por fecha+doctor
+    const storageKey = useMemo(() => `agenda:${doctorId}:${day}`, [doctorId, day]);
+    const { ordered: orderedAppts, onDragEnd } = useDndOrder(dayAppts, (a) => a.id, storageKey);
+
+    // ---- creación de turno ----
+    const [showNew, setShowNew] = useState(false);
+    const [newPatientId, setNewPatientId] = useState<string>(patients[0]?.id ?? "");
+    const [newStart, setNewStart] = useState<string>(() => `${day}T09:00`);
+    const [newDuration, setNewDuration] = useState<number>(20);
+    // const [newType, setNewType] = useState<"virtual" | "presencial">("virtual");
+    // const [newStatus, setNewStatus] = useState<"pending" | "confirmed" | "cancelled">("confirmed");
+    // estado TIPADO
+    const [newType, setNewType] = useState<Appointment["type"]>("virtual");
+    const [newStatus, setNewStatus] = useState<Appointment["status"]>("confirmed");
+
+    // handlers TIPADOS
+    const onChangeType = (e: React.ChangeEvent<HTMLSelectElement>) =>
+        setNewType(e.target.value as Appointment["type"]);
+
+    const onChangeStatus = (e: React.ChangeEvent<HTMLSelectElement>) =>
+        setNewStatus(e.target.value as Appointment["status"]);
+
+    // probando =)
+
+    useEffect(() => {
+        // si cambia el día, reseteamos la hora inicial
+        setNewStart(`${day}T09:00`);
+    }, [day]);
+
+    const handleCreate = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!newPatientId) {
+            toast.error("Selecciona un paciente");
+            return;
+        }
+        const startISO = new Date(newStart).toISOString();
+        const endsISO = addMinutes(new Date(newStart), newDuration).toISOString();
+
+        addAppointment({
+            id: crypto.randomUUID(),
+            doctorId,
+            patientId: newPatientId,
+            startsAt: startISO,
+            endsAt: endsISO,
+            type: newType,
+            status: newStatus,
+        });
+
+        toast.success("Turno creado");
+        setShowNew(false);
+    };
+
+    // ---- edición simple por fila ----
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [editStart, setEditStart] = useState<string>("");
+    const [editDuration, setEditDuration] = useState<number>(20);
+    const [editType, setEditType] = useState<"virtual" | "presencial">("virtual");
+    const [editStatus, setEditStatus] = useState<"pending" | "confirmed" | "cancelled">("confirmed");
+
+    const openEdit = (id: string) => {
+        const a = orderedAppts.find((x) => x.id === id);
+        if (!a) return;
+        setEditingId(id);
+        setEditStart(format(parseISO(a.startsAt), "yyyy-MM-dd'T'HH:mm"));
+        const minutes = Math.max(
+            5,
+            Math.round((+new Date(a.endsAt) - +new Date(a.startsAt)) / 60000)
+        );
+        setEditDuration(minutes);
+        setEditType(a.type);
+        setEditStatus(a.status);
+    };
+
+    const saveEdit = () => {
+        if (!editingId) return;
+        const startISO = new Date(editStart).toISOString();
+        const endISO = addMinutes(new Date(editStart), editDuration).toISOString();
+        updateAppointment(editingId, {
+            startsAt: startISO,
+            endsAt: endISO,
+            type: editType,
+            status: editStatus,
+        });
+        setEditingId(null);
+        toast.success("Turno actualizado");
+    };
+
+
+
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-primary/5 via-background to-secondary/5">
+            {/* Header */}
+            <header className="border-b bg-card/50 backdrop-blur-sm sticky top-0 z-10">
+                <div className="container mx-auto px-4 py-4 flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                        <Button variant="ghost" size="sm" onClick={() => navigate(-1)} className="gap-2">
+                            <ArrowLeft className="w-4 h-4" />
+                            Volver
+                        </Button>
+                        <div className="flex items-center gap-3">
+                            <div className="w-10 h-10 my-gradient-class rounded-xl flex items-center justify-center">
+                                <Activity className="w-5 h-5 text-white" />
+                            </div>
+                            <div>
+                                <h1 className="text-xl font-semibold">Gestión de agenda</h1>
+                                <p className="text-sm text-muted-foreground">Profesional: {doctors.find(d => d.id === doctorId)?.name ?? "—"}</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="flex items-center gap-3">
+                        <div className="flex items-center gap-2">
+                            <CalIcon className="w-4 h-4 text-primary" />
+                            <Input
+                                type="date"
+                                value={day}
+                                onChange={(e) => setDay(e.target.value)}
+                                className="h-8 w-[150px]"
+                            />
+                        </div>
+                        <Button onClick={() => setShowNew((v) => !v)} className="gap-2">
+                            <CalendarPlus className="w-4 h-4" />
+                            Nuevo turno
+                        </Button>
+                    </div>
+                </div>
+            </header>
+
+            <main className="container mx-auto px-4 py-8 space-y-8">
+                {/* Resumen */}
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                    <Card className="shadow-md">
+                        <CardContent className="pt-6">
+                            <p className="text-sm text-muted-foreground">Turnos del día</p>
+                            <h3 className="text-3xl font-bold mt-1">{dayAppts.length}</h3>
+                        </CardContent>
+                    </Card>
+                    <Card className="shadow-md">
+                        <CardContent className="pt-6">
+                            <p className="text-sm text-muted-foreground">Virtual / Presencial</p>
+                            <h3 className="text-3xl font-bold mt-1">
+                                {dayAppts.filter(a => a.type === "virtual").length} / {dayAppts.filter(a => a.type === "presencial").length}
+                            </h3>
+                        </CardContent>
+                    </Card>
+                    <Card className="shadow-md">
+                        <CardContent className="pt-6">
+                            <p className="text-sm text-muted-foreground">Pendientes</p>
+                            <h3 className="text-3xl font-bold mt-1">{dayAppts.filter(a => a.status === "pending").length}</h3>
+                        </CardContent>
+                    </Card>
+                </div>
+
+                {/* Form nuevo turno */}
+                {showNew && (
+                    <Card className="shadow-md">
+                        <CardHeader>
+                            <CardTitle className="flex items-center gap-2">
+                                <CalendarPlus className="w-5 h-5 text-primary" />
+                                Crear nuevo turno
+                            </CardTitle>
+                            <CardDescription>Completa los campos y guarda para agendar.</CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <form onSubmit={handleCreate} className="grid grid-cols-1 md:grid-cols-6 gap-4">
+                                <div className="md:col-span-2">
+                                    <Label>Paciente</Label>
+                                    <select
+                                        className="w-full border rounded-md h-10 px-3"
+                                        value={newPatientId}
+                                        onChange={(e) => setNewPatientId(e.target.value)}
+                                    >
+                                        {patients.map((p) => (
+                                            <option key={p.id} value={p.id}>{p.name}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                <div className="md:col-span-2">
+                                    <Label>Inicio</Label>
+                                    <Input
+                                        type="datetime-local"
+                                        value={newStart}
+                                        onChange={(e) => setNewStart(e.target.value)}
+                                    />
+                                </div>
+                                <div>
+                                    <Label>Duración (min)</Label>
+                                    <Input
+                                        type="number"
+                                        min={5}
+                                        step={5}
+                                        value={newDuration}
+                                        onChange={(e) => setNewDuration(parseInt(e.target.value || "20", 10))}
+                                    />
+                                </div>
+                                <div>
+                                    <Label>Tipo</Label>
+                                    <select
+                                        className="w-full border rounded-md h-10 px-3"
+                                        value={newType}
+                                        // onChange={(e) => setNewType(e.target.value as any)}
+                                        onChange={onChangeType}
+
+                                    >
+                                        <option value="virtual">Teleconsulta</option>
+                                        <option value="presencial">Presencial</option>
+                                    </select>
+                                </div>
+                                <div>
+                                    <Label>Estado</Label>
+                                    <select
+                                        className="w-full border rounded-md h-10 px-3"
+                                        value={newStatus}
+                                        // onChange={(e) => setNewStatus(e.target.value as any)}
+                                        onChange={onChangeStatus}
+
+                                    >
+                                        <option value="confirmed">Confirmada</option>
+                                        <option value="pending">Pendiente</option>
+                                        <option value="cancelled">Cancelada</option>
+                                    </select>
+                                </div>
+
+                                <div className="md:col-span-6 flex gap-2 justify-end pt-2">
+                                    <Button type="button" variant="outline" onClick={() => setShowNew(false)}>Cancelar</Button>
+                                    <Button type="submit">Guardar</Button>
+                                </div>
+
+                            </form>
+                        </CardContent>
+                    </Card>
+                )}
+
+                {/* Lista del día con DnD */}
+                <Card className="shadow-md">
+                    <CardHeader>
+                        <CardTitle className="flex items-center gap-2">
+                            <Clock className="w-5 h-5 text-primary" />
+                            Agenda del {format(new Date(day), "dd/MM/yyyy")}
+                        </CardTitle>
+                        <CardDescription>Arrastra para cambiar el orden visual del día.</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        {orderedAppts.length === 0 ? (
+                            <p className="text-sm text-muted-foreground">No hay turnos en este día.</p>
+                        ) : (
+                            <DragDropContext onDragEnd={onDragEnd}>
+                                <Droppable droppableId="day">
+                                    {(dropProvided) => (
+                                        <div ref={dropProvided.innerRef} {...dropProvided.droppableProps} className="space-y-3">
+                                            {orderedAppts.map((a, index) => {
+                                                const p = patients.find((x) => x.id === a.patientId);
+                                                const start = parseISO(a.startsAt);
+                                                const end = parseISO(a.endsAt);
+                                                const isEditing = editingId === a.id;
+
+                                                return (
+                                                    <Draggable key={a.id} draggableId={a.id} index={index}>
+                                                        {(dragProvided, snapshot) => (
+                                                            <div
+                                                                ref={dragProvided.innerRef}
+                                                                {...dragProvided.draggableProps}
+                                                                className={`border rounded-lg p-4 bg-card transition-colors ${snapshot.isDragging ? "ring-2 ring-primary/50 bg-accent/20" : "hover:bg-accent/5"}`}
+                                                            >
+                                                                <div className="flex items-center gap-3">
+                                                                    <div
+                                                                        {...dragProvided.dragHandleProps}
+                                                                        className="cursor-grab active:cursor-grabbing text-slate-400 select-none"
+                                                                        title="Arrastrar"
+                                                                    >
+                                                                        ⠿
+                                                                    </div>
+
+                                                                    <div className="flex-1">
+                                                                        <div className="flex flex-wrap items-center gap-2">
+                                                                            <div className="font-semibold">{p?.name ?? "Paciente"}</div>
+                                                                            <StatusBadge status={a.status} />
+                                                                            <Badge variant="outline">{a.type === "virtual" ? "Teleconsulta" : "Presencial"}</Badge>
+                                                                        </div>
+                                                                        <div className="text-sm text-muted-foreground mt-1">
+                                                                            {hhmm(start)} — {hhmm(end)} • DocID: {p?.docId ?? "—"}
+                                                                        </div>
+                                                                    </div>
+
+                                                                    <div className="flex gap-2">
+                                                                        <Button size="sm" variant="outline" className="gap-1" onClick={() => openEdit(a.id)}>
+                                                                            <Edit3 className="w-4 h-4" /> Editar
+                                                                        </Button>
+                                                                        {a.status !== "cancelled" ? (
+                                                                            <Button
+                                                                                size="sm"
+                                                                                variant="outline"
+                                                                                className="gap-1"
+                                                                                onClick={() => {
+                                                                                    updateAppointment(a.id, { status: "cancelled" });
+                                                                                    toast.message("Turno cancelado");
+                                                                                }}
+                                                                            >
+                                                                                <Trash2 className="w-4 h-4" /> Cancelar
+                                                                            </Button>
+                                                                        ) : (
+                                                                            <Button
+                                                                                size="sm"
+                                                                                className="gap-1"
+                                                                                onClick={() => {
+                                                                                    updateAppointment(a.id, { status: "confirmed" });
+                                                                                    toast.success("Turno reactivado");
+                                                                                }}
+                                                                            >
+                                                                                <CheckCircle className="w-4 h-4" /> Confirmar
+                                                                            </Button>
+                                                                        )}
+                                                                    </div>
+                                                                    <Button
+                                                                        variant="destructive"
+                                                                        size="sm"
+                                                                        onClick={() => {
+                                                                            if (confirm("¿Eliminar este turno?")) deleteAppointment(a.id);
+                                                                        }}
+                                                                    >
+                                                                        Eliminar
+                                                                    </Button>
+                                                                </div>
+
+                                                                {/* Editor inline */}
+                                                                {isEditing && (
+                                                                    <div className="mt-4 grid grid-cols-1 md:grid-cols-6 gap-3">
+                                                                        <div className="md:col-span-2">
+                                                                            <Label>Inicio</Label>
+                                                                            <Input
+                                                                                type="datetime-local"
+                                                                                value={editStart}
+                                                                                onChange={(e) => setEditStart(e.target.value)}
+                                                                            />
+                                                                        </div>
+                                                                        <div>
+                                                                            <Label>Duración (min)</Label>
+                                                                            <Input
+                                                                                type="number"
+                                                                                min={5}
+                                                                                step={5}
+                                                                                value={editDuration}
+                                                                                onChange={(e) => setEditDuration(parseInt(e.target.value || "20", 10))}
+                                                                            />
+                                                                        </div>
+                                                                        <div>
+                                                                            <Label>Tipo</Label>
+                                                                            <select
+                                                                                className="w-full border rounded-md h-10 px-3"
+                                                                                value={editType}
+                                                                                // onChange={(e) => setEditType(e.target.value as any)}
+                                                                                onChange={onChangeType}
+
+                                                                            >
+                                                                                <option value="virtual">Teleconsulta</option>
+                                                                                <option value="presencial">Presencial</option>
+                                                                            </select>
+                                                                        </div>
+                                                                        <div>
+                                                                            <Label>Estado</Label>
+                                                                            <select
+                                                                                className="w-full border rounded-md h-10 px-3"
+                                                                                value={editStatus}
+                                                                                // onChange={(e) => setEditStatus(e.target.value as any)}
+                                                                                onChange={onChangeStatus}
+
+                                                                            >
+                                                                                <option value="confirmed">Confirmada</option>
+                                                                                <option value="pending">Pendiente</option>
+                                                                                <option value="cancelled">Cancelada</option>
+                                                                            </select>
+                                                                        </div>
+                                                                        <div className="md:col-span-6 flex gap-2 justify-end">
+                                                                            <Button variant="outline" onClick={() => setEditingId(null)}>Cerrar</Button>
+                                                                            <Button onClick={saveEdit}>Guardar cambios</Button>
+                                                                        </div>
+                                                                    </div>
+                                                                )}
+                                                            </div>
+                                                        )}
+                                                    </Draggable>
+                                                );
+                                            })}
+                                            {dropProvided.placeholder}
+                                        </div>
+                                    )}
+                                </Droppable>
+                            </DragDropContext>
+                        )}
+                    </CardContent>
+                </Card>
+            </main>
+        </div>
+    );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -10,6 +10,7 @@ import { Outdent } from "lucide-react";
 import MedicalHistoryPage from "./features/medical/MedicalHistoryPage";
 import TeleconsultationPage from "./features/televisit/TeleconsultationPage";
 import DoctorAppointmentsPage from "./features/scheduling/DoctorAppointmentsPage";
+import PatientsPage from "./features/patients/PatientsPage";
 
 function RequireAuth({ children }: PropsWithChildren) {
   const user = useAppStore((s) => s.currentUser);
@@ -64,14 +65,8 @@ export default function AppRoutes() {
         </RequireAuth>
       }
       />
-      <Route
-        path="/doctor/appointments"
-        element={
-          <RequireAuth>
-            <DoctorAppointmentsPage />
-          </RequireAuth>
-        }
-      />
+      <Route path="/doctor/appointments" element={<RequireAuth> <DoctorAppointmentsPage /></RequireAuth>} />
+      <Route path="/patients" element={<RequireAuth> <PatientsPage /> </RequireAuth>} />
 
       {/* admin */}
       {/* <Route path="/admin" element={<AdminDashboard />} /> */}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -9,6 +9,7 @@ import type { PropsWithChildren } from "react";
 import { Outdent } from "lucide-react";
 import MedicalHistoryPage from "./features/medical/MedicalHistoryPage";
 import TeleconsultationPage from "./features/televisit/TeleconsultationPage";
+import DoctorAppointmentsPage from "./features/scheduling/DoctorAppointmentsPage";
 
 function RequireAuth({ children }: PropsWithChildren) {
   const user = useAppStore((s) => s.currentUser);
@@ -57,11 +58,17 @@ export default function AppRoutes() {
       <Route path="/doctor" element={<DoctorDashboard />} />
       {/* alias temporal para compatibilidad */}
       <Route path="/doctor-dashboard" element={<Navigate to="/doctor" replace />} />
+      <Route path="/televisit/:appointmentId" element={
+        <RequireAuth>
+          <TeleconsultationPage />
+        </RequireAuth>
+      }
+      />
       <Route
-        path="/televisit/:appointmentId"
+        path="/doctor/appointments"
         element={
           <RequireAuth>
-            <TeleconsultationPage />
+            <DoctorAppointmentsPage />
           </RequireAuth>
         }
       />

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -123,6 +123,10 @@ interface AppState {
 
     // acciones HC (mínimas por ahora)
     upsertClinicalRecord: (patientId: string, patch: Partial<ClinicalRecord>) => void;
+
+    updateAppointment: (id: string, patch: Partial<Appointment>) => void;
+    deleteAppointment: (id: string) => void;
+
 }
 
 /** Seeds demo */
@@ -457,7 +461,17 @@ const useAppStore = create<AppState>()(
                     },
                 });
             },
+            updateAppointment: (id, patch) =>
+                set((s) => ({
+                    appointments: s.appointments.map((a) =>
+                        a.id === id ? { ...a, ...patch } : a
+                    ),
+                })),
 
+            deleteAppointment: (id) =>
+                set((s) => ({
+                    appointments: s.appointments.filter((a) => a.id !== id),
+                })),
         }),
         {
             name: "hc/app-store",

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -127,6 +127,11 @@ interface AppState {
     updateAppointment: (id: string, patch: Partial<Appointment>) => void;
     deleteAppointment: (id: string) => void;
 
+    // gestion paciente
+    addPatient: (p: Omit<Patient, "id"> & { id?: string }) => string; // devuelve id
+    updatePatient: (id: string, patch: Partial<Patient>) => void;
+    deletePatient?: (id: string) => void;
+
 }
 
 /** Seeds demo */
@@ -472,6 +477,22 @@ const useAppStore = create<AppState>()(
                 set((s) => ({
                     appointments: s.appointments.filter((a) => a.id !== id),
                 })),
+
+
+            // gestio paciente
+            addPatient: (p) => {
+                const id = p.id ?? `p-${crypto.randomUUID()}`;
+                set((s) => ({ patients: [...s.patients, { id, ...p }] }));
+                return id;
+            },
+
+            updatePatient: (id, patch) =>
+                set((s) => ({
+                    patients: s.patients.map(pt => (pt.id === id ? { ...pt, ...patch } : pt)),
+                })),
+
+            deletePatient: (id) =>
+                set((s) => ({ patients: s.patients.filter(pt => pt.id !== id) })),
         }),
         {
             name: "hc/app-store",


### PR DESCRIPTION
# Se añade la sección para Teleconsultas y la Gestión de la Agenda

* Nueva Página  televisit/:appointmentId para las teleconsultas
* Nueva Página /doctor/appointments para administrar turnos.
* Formulario de alta/edición y selección de paciente/estado/tipo
* usando el hook useDndOrder para reordenamiento manual.
* Orden y filtro de “turnos de hoy” con date-fns 
* Fix TS: tipado de selects (Appointment["type"] y Appointment["status"]) y eliminación de any.
* Botón “Eliminar” por turno + confirmación (solo alert para confirmar.. a futuro hay que añadir algún modal o popup )

