### PR TITLE
Guille nec certificados recetas

### DIFF
--- a/src/features/doctor/SignatureSettingsPage.tsx
+++ b/src/features/doctor/SignatureSettingsPage.tsx
@@ -3,7 +3,7 @@ import useAppStore from "@/store/appStore";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { Activity, ArrowLeft } from "lucide-react";
+import { Activity, ArrowLeft, Upload } from "lucide-react";
 import { useNavigate } from "react-router";
 
 function fileToDataURL(f: File): Promise<string> {
@@ -63,22 +63,27 @@ export default function SignatureSettingsPage() {
                 <Card>
                     <CardHeader><CardTitle>Firma y sello digital</CardTitle></CardHeader>
                     <CardContent className="grid md:grid-cols-2 gap-6">
-                        <div className="space-y-2">
-                            <Label>Firma (PNG con fondo transparente)</Label>
+                        <div className="w-full h-auto space-y-2 flex flex-col justify-center items-center border-2 border-slate-300 rounded-md relative">
+                            <Label htmlFor="file_firma" className="w-auto max-w-full text-xs md:text-[15px] xl:text-lg">Firma (PNG con fondo transparente)
+                                <Upload />
+
+                            </Label>
                             <input
-                                type="file" accept="image/png"
+                                type="file" id="file_firma" accept="image/png" className="w-auto max-w-full h-auto px-2 text-center text-xs md:text-[15px] xl:text-lg"
                                 onChange={async (e) => {
                                     const f = e.target.files?.[0]; if (!f) return;
                                     const url = await fileToDataURL(f);
                                     setSig(url);
                                 }}
-                            />
+                            ></input>
                             {sig && <img src={sig} alt="firma" className="h-24 object-contain border rounded" />}
                         </div>
-                        <div className="space-y-2">
-                            <Label>Sello (PNG con fondo transparente)</Label>
+                        <div className="space-y-2 flex flex-col justify-center items-center border-2 border-slate-300 rounded-md">
+                            <Label htmlFor="file_sello" className="w-auto max-w-full text-xs md:text-[15px] xl:text-lg">Sello (PNG con fondo transparente)
+                                <Upload />
+                            </Label>
                             <input
-                                type="file" accept="image/png"
+                                type="file" id="file_sello" accept="image/png" className="w-auto max-w-full h-auto px-2 text-center text-xs md:text-[15px] xl:text-lg"
                                 onChange={async (e) => {
                                     const f = e.target.files?.[0]; if (!f) return;
                                     const url = await fileToDataURL(f);

--- a/src/features/medical/MedicalHistoryPage.tsx
+++ b/src/features/medical/MedicalHistoryPage.tsx
@@ -10,6 +10,8 @@ import { ConsultationsList } from "./components/ConsultationsList";
 import { MedicationsList } from "./components/MedicationsList";
 import { LabsList } from "./components/LabsList";
 import { VitalsList } from "./components/VitalsList";
+import PatientPrescriptionsTab from "../patients/tabs/PatientPrescriptionsTab";
+import PatientCertificatesTab from "../patients/tabs/PatientCertificatesTab";
 
 
 function fdate(iso: string) {
@@ -81,11 +83,14 @@ export default function MedicalHistoryPage() {
                 />
 
                 <Tabs defaultValue="consultations" className="space-y-6">
-                    <TabsList className="grid w-full grid-cols-4">
+                    <TabsList className="grid w-full h-auto grid-cols-3 gap-2 md:grid-cols-6 md:gap-2 ">
                         <TabsTrigger value="consultations">Consultas</TabsTrigger>
                         <TabsTrigger value="medications">Medicación</TabsTrigger>
                         <TabsTrigger value="labs">Laboratorio</TabsTrigger>
                         <TabsTrigger value="vitals">Signos vitales</TabsTrigger>
+
+                        <TabsTrigger value="reset">Recetas</TabsTrigger>
+                        <TabsTrigger value="certificate">Certificados</TabsTrigger>
                     </TabsList>
 
                     <TabsContent value="consultations">
@@ -105,6 +110,13 @@ export default function MedicalHistoryPage() {
 
                     <TabsContent value="vitals">
                         <VitalsList items={record?.vitals ?? []} />
+                    </TabsContent>
+
+                    <TabsContent value="reset">
+                        <PatientPrescriptionsTab patientId={patient.id} />
+                    </TabsContent>
+                    <TabsContent value="certificate">
+                        <PatientCertificatesTab patientId={patient.id} />
                     </TabsContent>
                 </Tabs>
             </main>

--- a/src/features/medical/NewCertificatePage.tsx
+++ b/src/features/medical/NewCertificatePage.tsx
@@ -30,9 +30,36 @@ export default function NewCertificatePage() {
         if (!canSave) return;
         const p = patients.find(x => x.id === patientId)!;
 
+        // const fileUrl = genCertificatePdf({
+        //     doctor: { name: doctor.name, license: doctor.license, signaturePng: doctor.signaturePng, stampPng: doctor.stampPng },
+        //     patient: { name: p.name, docId: p.docId },
+        //     body: {
+        //         reason,
+        //         recommendations: recommendations || undefined,
+        //         period: fromISO && toISO ? { fromISO, toISO } : undefined,
+        //     }
+        // });
+
+        // const id = addCertificate(patientId, {
+        //     reason,
+        //     recommendations: recommendations || undefined,
+        //     period: fromISO && toISO ? { fromISO, toISO } : undefined,
+        //     fileUrl
+        // });
+
+        // para certificados
+        const doctorSnap = {
+            name: doctor.name,
+            license: doctor.license,
+            signaturePng: doctor.signaturePng,
+            stampPng: doctor.stampPng,
+        };
+        const patientSnap = { name: p.name, docId: p.docId };
+
+        // generar y abrir ahora
         const fileUrl = genCertificatePdf({
-            doctor: { name: doctor.name, license: doctor.license, signaturePng: doctor.signaturePng, stampPng: doctor.stampPng },
-            patient: { name: p.name, docId: p.docId },
+            doctor: doctorSnap,
+            patient: patientSnap,
             body: {
                 reason,
                 recommendations: recommendations || undefined,
@@ -40,11 +67,14 @@ export default function NewCertificatePage() {
             }
         });
 
+        // persistir con snapshots (no rompe nada si luego no los usás)
         const id = addCertificate(patientId, {
             reason,
             recommendations: recommendations || undefined,
             period: fromISO && toISO ? { fromISO, toISO } : undefined,
-            fileUrl
+            fileUrl,
+            doctorSnapshot: doctorSnap,
+            patientSnapshot: patientSnap,
         });
 
         toast.success("Certificado generado");

--- a/src/features/medical/NewPrescriptionPage.tsx
+++ b/src/features/medical/NewPrescriptionPage.tsx
@@ -36,18 +36,42 @@ export default function NewPrescriptionPage() {
     const onSave = () => {
         if (!canSave || !patient) return;
 
+        // const fileUrl = genPrescriptionPdf({
+        //     doctor: { name: doctor.name, license: doctor.license, signaturePng: doctor.signaturePng, stampPng: doctor.stampPng },
+        //     patient: { name: patient.name, docId: patient.docId, insurance: patient.insurance },
+        //     diagnosis: diagnosis || undefined,
+        //     items
+        // });
+
+        // const id = addPrescription(patientId, {
+        //     diagnosis: diagnosis || undefined,
+        //     items,
+        //     insuranceSnapshot: patient.insurance,
+        //     fileUrl
+        // });
+
+        const doctorSnap = {
+            name: doctor.name,
+            license: doctor.license,
+            signaturePng: doctor.signaturePng,
+            stampPng: doctor.stampPng,
+        };
+        const patientSnap = { name: patient.name, docId: patient.docId, insurance: patient.insurance };
+
         const fileUrl = genPrescriptionPdf({
-            doctor: { name: doctor.name, license: doctor.license, signaturePng: doctor.signaturePng, stampPng: doctor.stampPng },
-            patient: { name: patient.name, docId: patient.docId, insurance: patient.insurance },
+            doctor: doctorSnap,
+            patient: patientSnap,
             diagnosis: diagnosis || undefined,
-            items
+            items,
         });
 
         const id = addPrescription(patientId, {
             diagnosis: diagnosis || undefined,
             items,
             insuranceSnapshot: patient.insurance,
-            fileUrl
+            fileUrl,
+            doctorSnapshot: doctorSnap,
+            patientSnapshot: patientSnap,
         });
 
         toast.success("Receta generada");

--- a/src/features/medical/pdfAction.md
+++ b/src/features/medical/pdfAction.md
@@ -1,0 +1,15 @@
+# Como usarlo
+
+```tsx
+// p.ej. en PatientDetailPage.tsx (o donde listes los docs)
+import { openCertificatePdf, openPrescriptionPdf } from "@/features/medical/pdfActions";
+
+// ...
+<Button variant="outline" onClick={() => openCertificatePdf(cert)}>
+  Ver certificado
+</Button>
+
+<Button variant="outline" onClick={() => openPrescriptionPdf(rx)}>
+  Ver receta
+</Button>
+```

--- a/src/features/medical/pdfActions.ts
+++ b/src/features/medical/pdfActions.ts
@@ -1,0 +1,68 @@
+// src/features/medical/pdfActions.ts
+import { genCertificatePdf, genPrescriptionPdf } from "@/lib/pdf";
+import useAppStore, { type Certificate, type Prescription } from "@/store/appStore";
+
+/** Abre en una pestaña el PDF de un certificado.
+ *  Usa snapshot si existe; si no, toma los datos actuales del store. */
+export function openCertificatePdf(cert: Certificate) {
+    const { doctors, patients } = useAppStore.getState();
+
+    const doctor =
+        cert.doctorSnapshot ??
+        (() => {
+            const d = doctors.find(x => x.id === cert.doctorId);
+            return d
+                ? { name: d.name, license: d.license, signaturePng: d.signaturePng, stampPng: d.stampPng }
+                : { name: "—" };
+        })();
+
+    const patient =
+        cert.patientSnapshot ??
+        (() => {
+            const p = patients.find(x => x.id === cert.patientId);
+            return p ? { name: p.name, docId: p.docId } : { name: "—" };
+        })();
+
+    const url = genCertificatePdf({
+        doctor,
+        patient,
+        body: {
+            reason: cert.reason,
+            recommendations: cert.recommendations,
+            period: cert.period,
+        },
+    });
+
+    window.open(url, "_blank");
+}
+
+/** Abre en una pestaña el PDF de una receta.
+ *  Usa snapshot si existe; si no, toma los datos actuales del store. */
+export function openPrescriptionPdf(rx: Prescription) {
+    const { doctors, patients } = useAppStore.getState();
+
+    const doctor =
+        rx.doctorSnapshot ??
+        (() => {
+            const d = doctors.find(x => x.id === rx.doctorId);
+            return d
+                ? { name: d.name, license: d.license, signaturePng: d.signaturePng, stampPng: d.stampPng }
+                : { name: "—" };
+        })();
+
+    const patient =
+        rx.patientSnapshot ??
+        (() => {
+            const p = patients.find(x => x.id === rx.patientId);
+            return p ? { name: p.name, docId: p.docId, insurance: rx.insuranceSnapshot ?? p.insurance } : { name: "—" };
+        })();
+
+    const url = genPrescriptionPdf({
+        doctor,
+        patient,
+        diagnosis: rx.diagnosis,
+        items: rx.items,
+    });
+
+    window.open(url, "_blank");
+}

--- a/src/features/patients/tabs/PatientCertificatesTab.tsx
+++ b/src/features/patients/tabs/PatientCertificatesTab.tsx
@@ -1,0 +1,57 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import useAppStore from "@/store/appStore";
+import { format } from "date-fns";
+import { openCertificatePdf } from "@/features/medical/pdfActions";
+
+export default function PatientCertificatesTab({ patientId }: { patientId: string }) {
+    const { clinicalRecords, doctors } = useAppStore();
+
+    const items = [...(clinicalRecords[patientId]?.certificates ?? [])]
+        .sort((a, b) => (b.dateISO || "").localeCompare(a.dateISO || ""));
+
+    if (items.length === 0) {
+        return <p className="text-sm text-muted-foreground">No hay certificados registrados para este paciente.</p>;
+    }
+
+    return (
+        <div className="space-y-4">
+            {items.map((cert) => {
+                const docName = doctors.find(d => d.id === cert.doctorId)?.name ?? "—";
+                const date = cert.dateISO ? format(new Date(cert.dateISO), "d MMM yyyy") : "—";
+                return (
+                    <Card key={cert.id} id={`cert-${cert.id}`} className="shadow-sm">
+                        <CardHeader className="flex flex-row items-center justify-between">
+                            <CardTitle className="text-base">Certificado • {date}</CardTitle>
+                            <div className="text-sm text-muted-foreground">Dr/a: {docName}</div>
+                        </CardHeader>
+                        <CardContent className="space-y-2">
+                            <p className="text-sm"><span className="font-medium">Motivo:</span> {cert.reason}</p>
+                            {cert.period && (
+                                <p className="text-sm">
+                                    <span className="font-medium">Período:</span>{" "}
+                                    {format(new Date(cert.period.fromISO), "d MMM yyyy")} – {format(new Date(cert.period.toISO), "d MMM yyyy")}
+                                </p>
+                            )}
+                            {cert.recommendations && (
+                                <p className="text-sm"><span className="font-medium">Recomendaciones:</span> {cert.recommendations}</p>
+                            )}
+
+                            <div className="flex gap-2 pt-2">
+                                <Button variant="outline" onClick={() => openCertificatePdf(cert)}>Ver PDF</Button>
+                                {cert.fileUrl && (
+                                    <Button
+                                        variant="ghost"
+                                        onClick={() => window.open(cert.fileUrl!, "_blank")}
+                                    >
+                                        Abrir archivo guardado
+                                    </Button>
+                                )}
+                            </div>
+                        </CardContent>
+                    </Card>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/features/patients/tabs/PatientPrescriptionsTab.tsx
+++ b/src/features/patients/tabs/PatientPrescriptionsTab.tsx
@@ -1,0 +1,56 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import useAppStore from "@/store/appStore";
+import { format } from "date-fns";
+import { openPrescriptionPdf } from "@/features/medical/pdfActions";
+
+export default function PatientPrescriptionsTab({ patientId }: { patientId: string }) {
+    const { clinicalRecords, doctors } = useAppStore();
+
+    const items = [...(clinicalRecords[patientId]?.prescriptions ?? [])]
+        .sort((a, b) => (b.dateISO || "").localeCompare(a.dateISO || ""));
+
+    if (items.length === 0) {
+        return <p className="text-sm text-muted-foreground">No hay recetas registradas para este paciente.</p>;
+    }
+
+    return (
+        <div className="space-y-4">
+            {items.map((rx) => {
+                const docName = doctors.find(d => d.id === rx.doctorId)?.name ?? "—";
+                const date = rx.dateISO ? format(new Date(rx.dateISO), "d MMM yyyy") : "—";
+                const firstDrug = rx.items[0]?.drug ?? "";
+                const more = Math.max(0, rx.items.length - 1);
+                return (
+                    <Card key={rx.id} id={`rx-${rx.id}`} className="shadow-sm">
+                        <CardHeader className="flex flex-row items-center justify-between">
+                            <CardTitle className="text-base">Receta • {date}</CardTitle>
+                            <div className="text-sm text-muted-foreground">Dr/a: {docName}</div>
+                        </CardHeader>
+                        <CardContent className="space-y-2">
+                            {rx.diagnosis && (
+                                <p className="text-sm">
+                                    <span className="font-medium">Diagnóstico:</span> {rx.diagnosis}
+                                </p>
+                            )}
+                            <p className="text-sm">
+                                <span className="font-medium">Medicamentos:</span> {firstDrug}{more > 0 ? ` (+${more} más)` : ""}
+                            </p>
+                            <div className="flex gap-2 pt-2">
+                                <Button variant="outline" onClick={() => openPrescriptionPdf(rx)}>Ver PDF</Button>
+                                {rx.fileUrl && (
+                                    <Button
+                                        variant="ghost"
+                                        onClick={() => window.open(rx.fileUrl!, "_blank")}
+                                    >
+                                        Abrir archivo guardado
+                                    </Button>
+                                )}
+                            </div>
+                        </CardContent>
+                    </Card>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/features/scheduling/DoctorAppointmentsPage.tsx
+++ b/src/features/scheduling/DoctorAppointmentsPage.tsx
@@ -156,8 +156,6 @@ export default function DoctorAppointmentsPage() {
         toast.success("Turno actualizado");
     };
 
-
-
     return (
         <div className="min-h-screen bg-gradient-to-br from-primary/5 via-background to-secondary/5">
             {/* Header */}
@@ -321,6 +319,7 @@ export default function DoctorAppointmentsPage() {
                                             {orderedAppts.map((a, index) => {
                                                 const p = patients.find((x) => x.id === a.patientId);
                                                 const start = parseISO(a.startsAt);
+                                                // const end = parseISO(a.endsAt);
                                                 const end = parseISO(a.endsAt);
                                                 const isEditing = editingId === a.id;
 

--- a/src/features/scheduling/DoctorAppointmentsPage.tsx
+++ b/src/features/scheduling/DoctorAppointmentsPage.tsx
@@ -10,7 +10,7 @@ import { Activity, ArrowLeft, CalendarPlus, Calendar as CalIcon, CheckCircle, Cl
 import { toast } from "sonner";
 import useAppStore, { type Appointment } from "@/store/appStore";
 import { useDndOrder } from "@/hooks/useDndOrder";
-import { addMinutes, compareAsc, endOfDay, format, parseISO, startOfDay, isWithinInterval } from "date-fns";
+import { addMinutes, compareAsc, endOfDay, format, parse, parseISO, startOfDay, isWithinInterval } from "date-fns";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
 
 function StatusBadge({ status }: { status: "pending" | "confirmed" | "cancelled" }) {
@@ -51,8 +51,13 @@ export default function DoctorAppointmentsPage() {
         // sanity: si cambia doctor, mantenemos el día actual
     }, [doctorId]);
 
-    const dayStart = useMemo(() => startOfDay(new Date(day)), [day]);
-    const dayEnd = useMemo(() => endOfDay(new Date(day)), [day]);
+    // const dayStart = useMemo(() => startOfDay(new Date(day)), [day]);
+    // const dayEnd = useMemo(() => endOfDay(new Date(day)), [day]);
+
+    // Después (día local, sin shift de huso)
+    const dayDate = useMemo(() => parse(day, "yyyy-MM-dd", new Date()), [day]);
+    const dayStart = useMemo(() => startOfDay(dayDate), [dayDate]);
+    const dayEnd = useMemo(() => endOfDay(dayDate), [dayDate]);
 
     const dayAppts = useMemo(() => {
         return appointments
@@ -301,7 +306,7 @@ export default function DoctorAppointmentsPage() {
                     <CardHeader>
                         <CardTitle className="flex items-center gap-2">
                             <Clock className="w-5 h-5 text-primary" />
-                            Agenda del {format(new Date(day), "dd/MM/yyyy")}
+                            Agenda del {format(dayDate, "dd/MM/yyyy")}
                         </CardTitle>
                         <CardDescription>Arrastra para cambiar el orden visual del día.</CardDescription>
                     </CardHeader>

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -29,6 +29,18 @@ export interface Patient {
     };
 }
 
+export type DoctorSnapshot = {
+    name: string;
+    license?: string;
+    signaturePng?: string;
+    stampPng?: string;
+};
+
+export type PatientSnapshot = {
+    name: string;
+    docId?: string;
+    insurance?: Patient["insurance"];
+};
 // ++++ certificados-recetas PDF +++
 // Documentos
 export type Certificate = {
@@ -40,6 +52,8 @@ export type Certificate = {
     recommendations?: string;  // reposo, restricciones, etc.
     period?: { fromISO: string; toISO: string };
     fileUrl?: string;          // blob URL del PDF generado
+    doctorSnapshot?: DoctorSnapshot;
+    patientSnapshot?: PatientSnapshot;
 };
 
 export type RxItem = {
@@ -58,6 +72,9 @@ export type Prescription = {
     items: RxItem[];
     insuranceSnapshot?: Patient["insurance"]; // copia al momento de emitir
     fileUrl?: string;
+
+    doctorSnapshot?: DoctorSnapshot;
+    patientSnapshot?: PatientSnapshot;
 };
 
 // ++++ FIN - certificados-recetas PDF +++
@@ -627,6 +644,10 @@ const useAppStore = create<AppState>()(
                     recommendations: data.recommendations,
                     period: data.period,
                     fileUrl: data.fileUrl,
+
+                    // 👇 nuevos (opcionales)
+                    doctorSnapshot: data.doctorSnapshot,
+                    patientSnapshot: data.patientSnapshot,
                 };
                 set({
                     clinicalRecords: {
@@ -649,6 +670,10 @@ const useAppStore = create<AppState>()(
                     items: data.items,
                     insuranceSnapshot: data.insuranceSnapshot,
                     fileUrl: data.fileUrl,
+
+                    // 👇 nuevos (opcionales)
+                    doctorSnapshot: data.doctorSnapshot,
+                    patientSnapshot: data.patientSnapshot,
                 };
                 set({
                     clinicalRecords: {


### PR DESCRIPTION
* Store: agrego tipos Certificate, Prescription, RxItem y campos opcionales en Doctor (license, signaturePng, stampPng) y Patient.insurance.

* Persistencia: nuevas acciones addCertificate, addPrescription, updateDoctorProfile; se guardan en clinicalRecords[patientId] y quedan incluidas en zustand/persist.

* PDF: helpers openPrescriptionPdf y openCertificatePdf para regenerar/abrir PDFs desde cualquier lugar (reutiliza genPrescriptionPdf / genCertificatePdf).

* UI médico: páginas de “Nueva receta” y “Nuevo certificado” actualizadas para guardar en store y abrir el PDF generado.

* Historial del paciente: nuevas pestañas Recetas y Certificados con timeline, doctor, fecha y botón “Ver PDF”. 

**Revisa: src/features/medical/pdfActions.ts**.. te deje un .md de como usarlo